### PR TITLE
Fix cloud stuttering (use render time instead of world time)

### DIFF
--- a/assets/lumi/shaders/func/volumetric_cloud.glsl
+++ b/assets/lumi/shaders/func/volumetric_cloud.glsl
@@ -198,7 +198,7 @@ vec4 generateCloudTexture(vec2 texcoord) {
     #if VOLUMETRIC_CLOUD_MODE == VOLUMETRIC_CLOUD_MODE_SKYBOX
         worldXz -= frx_cameraPos().xz * 0.8;
     #endif
-    vec2 cloudCoord = worldXz + (frx_worldDay() + frx_worldTime()) * 800.0;
+    vec2 cloudCoord = worldXz + frx_renderSeconds(); //worldXz + (frx_worldDay() + frx_worldTime()) * 800.0;
     cloudCoord *= 2.0;
 
     float cloudBase = l2_clampScale(0.0, 1.0 - rainFactor, snoise(cloudCoord * 0.005));


### PR DESCRIPTION
This commit fixes cloud stuttering by making it not depend on world time, but rather on render time (just like vanilla Minecraft).
You can see it in action here: https://youtu.be/gQSkw1CsvyE