### PR TITLE
Fix variable `hlLight` could be uninitialized in `lights` function

### DIFF
--- a/assets/lumi/shaders/prog/shading.glsl
+++ b/assets/lumi/shaders/prog/shading.glsl
@@ -289,6 +289,7 @@ void lights(vec3 albedo, vec4 light, vec3 eyePos, vec3 toEye, out vec3 baseLight
 	blockLight = blColor * BLOCK_LIGHT_STR * bl * adaptationTerm;
 	blockLight *= 0.7 + userBrightness * 0.4;
 
+	hlLight = vec3(0.0);
 #if HANDHELD_LIGHT_RADIUS != 0
 	if (frx_heldLight.w > 0) {
 		vec3 toLight = toEye;
@@ -379,10 +380,8 @@ vec4 particleShading(vec4 color, sampler2D natureTexture, vec4 light, vec3 eyePo
 	vec3 toEye = -normalize(eyePos);
 	prepare(color, natureTexture, eyePos, 1.0, isUnderwater, light);
 
-	vec3 baseLight = vec3(0.0);
-	vec3 blockLight = vec3(0.0);
-	vec3 hlLight = vec3(0.0);
-	vec3 skyLight = vec3(0.0);
+	vec3 baseLight, blockLight, hlLight, skyLight;
+
 	lights(albedo, light, eyePos, toEye, baseLight, blockLight, hlLight, skyLight);
 
 	vec3 shaded = albedo * (baseLight + blockLight + hlLight);


### PR DESCRIPTION
[This](https://github.com/spiralhalo/LumiLights/commit/473fadf5e8c53e527151b763f65d31630e8f08cd) commit fixed uninitialized variables for one function call: https://github.com/spiralhalo/LumiLights/blob/473fadf5e8c53e527151b763f65d31630e8f08cd/assets/lumi/shaders/prog/shading.glsl#L384 , but not for other one: https://github.com/spiralhalo/LumiLights/blob/473fadf5e8c53e527151b763f65d31630e8f08cd/assets/lumi/shaders/prog/shading.glsl#L336